### PR TITLE
Update quick start and project structure docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,9 +38,7 @@ Familiarize yourself with this structure to locate relevant code and configurati
 ├── docs/                               # Developer documentation and guides
 │   ├── DEVELOPING_PROCESSORS.md        # How to build new custom processors
 │   └── NRDOT_PROCESSOR_SELF_OBSERVABILITY.md # Standards for processor metrics
-├── examples/                           # Standalone example code
-│   └── simple_demo/                    # Minimal Go HTTP demo application
-│       └── main.go
+├── main.go                             # Standalone "Hello World" demo application
 ├── processors/                         # Location for all custom OTel processors
 │   └── helloworld/                     # Phase 0: Example "Hello World" processor
 │       ├── config.go                   # Configuration struct and validation
@@ -79,7 +77,7 @@ The Makefile is your primary interface for common tasks. Refer to it (`make help
 | `make test` | Runs all available tests (unit, URL checks; future: integration, E2E). |
 | `make test-unit` | Runs Go unit tests (`go test ./...`). |
 | `make lint` | Runs Go static analysis tools (`go vet`, `go fmt`, `golangci-lint` if available). |
-| `make run-demo` | Executes the simple Go demo in `examples/simple_demo/main.go`. |
+| `make run-demo` | Executes the simple Go demo in `main.go`. |
 
 ### Typical Local Development Loop for a Processor:
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ git clone https://github.com/newrelic/nrdot-process-optimization.git
 cd nrdot-process-optimization
 
 # 2. Run the simple demo
-go run examples/simple_demo/main.go
+go run main.go
 
 # 3. Access in your browser:
 #    → http://localhost:8080
@@ -174,9 +174,7 @@ The Makefile is the primary entry point for most development tasks.
 ├── docs/                               # Project documentation
 │   ├── DEVELOPING_PROCESSORS.md        # Guide for creating new custom processors
 │   └── NRDOT_PROCESSOR_SELF_OBSERVABILITY.md # Standards for processor metrics
-├── examples/                           # Standalone example code
-│   └── simple_demo/                    # Minimal Go HTTP demo application
-│       └── main.go
+├── main.go                             # Standalone "Hello World" demo application
 ├── processors/                         # Custom OpenTelemetry processors
 │   └── helloworld/                     # Phase 0: Example "Hello World" processor
 │   └── (prioritytagger/)               # (Future) L0: Critical process tagging


### PR DESCRIPTION
## Summary
- run demo via `go run main.go`
- list `main.go` in project structure and drop old examples directory
- sync CLAUDE guidelines with the new layout

## Testing
- `go test ./...` *(fails: missing go.sum entries)*