### PR TITLE
Add COLLECTOR_CONFIG override

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ cd nrdot-process-optimization
 make docker-build
 
 # 3. Start the local development stack using Docker Compose
-#    (This uses build/docker-compose.yaml and config/opt-plus.yaml)
+#    (Uses build/docker-compose.yaml and config/opt-plus.yaml by default)
 make compose-up
+# To use a custom collector config:
+# COLLECTOR_CONFIG=my-config.yaml make compose-up
 
 # 4. To view logs from all services (Collector, Mock Sink, etc.):
 #    (Run in a new terminal or after detaching from compose-up if it wasn't run with -d)
@@ -65,6 +67,8 @@ To test the complete optimization pipeline with all processors (PriorityTagger, 
 ```bash
 # Builds the collector, starts the stack with opt-plus.yaml, and verifies all processors
 ./test/test_opt_plus_pipeline.sh
+# Use a custom config file
+COLLECTOR_CONFIG=my-config.yaml ./test/test_opt_plus_pipeline.sh
 ```
 
 **Option 2:** Use the Makefile target:
@@ -74,6 +78,8 @@ make docker-build
 
 # Start the full optimization pipeline with opt-plus.yaml
 make opt-plus-up
+# With a custom config file
+COLLECTOR_CONFIG=my-config.yaml make opt-plus-up
 
 # View the logs to see the pipeline in action
 make logs
@@ -112,6 +118,7 @@ Key customization options include:
 - TopK value and dynamic K parameters
 - Reservoir size
 - Output attributes for rollup
+- Collector configuration file (COLLECTOR_CONFIG)
 
 Local Development Stack Service URLs (when make compose-up is running):
 | Service | URL | Purpose |

--- a/build/docker-compose.yaml
+++ b/build/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
       dockerfile: build/Dockerfile
     image: nrdot-process-optimization:latest
     container_name: otel-collector
-    command: ["--config=/etc/otel/config/opt-plus.yaml"]
+    command: ["--config=/etc/otel/config/${COLLECTOR_CONFIG:-opt-plus.yaml}"]
     volumes:
       - ../config:/etc/otel/config
     ports:

--- a/run.sh
+++ b/run.sh
@@ -24,6 +24,9 @@ display_usage() {
   echo -e "  --no-browser   Don't automatically open URLs in the browser"
   echo -e "  --open-urls    Open URLs in the browser (default)"
   echo
+  echo -e "Environment Variables:"
+  echo -e "  COLLECTOR_CONFIG  Collector config file (default: opt-plus.yaml)"
+  echo
   echo -e "Examples:"
   echo -e "  ./run.sh up                     Start services with Docker"
   echo -e "  ./run.sh up --no-browser        Start services without opening URLs"

--- a/test/test_opt_plus_pipeline.sh
+++ b/test/test_opt_plus_pipeline.sh
@@ -18,8 +18,9 @@ make docker-build || { echo -e "${RED}Failed to build Docker image${NC}"; exit 1
 echo -e "${GREEN}✅ Custom collector built successfully${NC}\n"
 
 # Step 2: Start the optimization pipeline with the opt-plus config
-echo -e "${BLUE}Step 2: Starting the optimization pipeline with opt-plus.yaml...${NC}"
-export COLLECTOR_CONFIG="opt-plus.yaml"
+CONFIG_FILE="${COLLECTOR_CONFIG:-opt-plus.yaml}"
+echo -e "${BLUE}Step 2: Starting the optimization pipeline with ${CONFIG_FILE}...${NC}"
+export COLLECTOR_CONFIG="${CONFIG_FILE}"
 make compose-up || { echo -e "${RED}Failed to start Docker Compose stack${NC}"; exit 1; }
 echo -e "${GREEN}✅ Optimization pipeline started${NC}\n"
 


### PR DESCRIPTION
## Summary
- allow custom collector config via `COLLECTOR_CONFIG`
- document `COLLECTOR_CONFIG` usage in README
- show environment variable in run script
- enable custom config in test script

## Testing
- `go test ./...` *(fails: proxyconnect tcp: no route to host)*
- `COLLECTOR_CONFIG=config/opt-plus.yaml bash test/test_opt_plus_pipeline.sh` *(fails: docker not found)*