### PR TITLE
Refactor metric helpers into shared package

### DIFF
--- a/internal/metricutil/README.md
+++ b/internal/metricutil/README.md
@@ -1,0 +1,10 @@
+# Metric Utility Package
+
+`metricutil` provides small helper functions for working with `pmetric` data structures. These utilities are shared across processors to reduce code duplication.
+
+## Functions
+
+- **GetNumericValue** - Returns the numeric value from a `NumberDataPoint` as a `float64`, handling both int and double types.
+- **MetricPointCount** - Counts the total number of data points contained in a `pmetric.Metrics` collection.
+
+These helpers are internal-only and intended for use by processors within this repository.

--- a/internal/metricutil/metricutil.go
+++ b/internal/metricutil/metricutil.go
@@ -1,0 +1,43 @@
+package metricutil
+
+import "go.opentelemetry.io/collector/pdata/pmetric"
+
+// GetNumericValue returns the numeric value of a NumberDataPoint as a float64.
+func GetNumericValue(dp pmetric.NumberDataPoint) float64 {
+	switch dp.ValueType() {
+	case pmetric.NumberDataPointValueTypeInt:
+		return float64(dp.IntValue())
+	case pmetric.NumberDataPointValueTypeDouble:
+		return dp.DoubleValue()
+	}
+	return 0
+}
+
+// MetricPointCount counts the total number of data points contained in a
+// pmetric.Metrics collection.
+func MetricPointCount(md pmetric.Metrics) int {
+	count := 0
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		rm := md.ResourceMetrics().At(i)
+		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+			sm := rm.ScopeMetrics().At(j)
+			for k := 0; k < sm.Metrics().Len(); k++ {
+				metric := sm.Metrics().At(k)
+
+				switch metric.Type() {
+				case pmetric.MetricTypeGauge:
+					count += metric.Gauge().DataPoints().Len()
+				case pmetric.MetricTypeSum:
+					count += metric.Sum().DataPoints().Len()
+				case pmetric.MetricTypeHistogram:
+					count += metric.Histogram().DataPoints().Len()
+				case pmetric.MetricTypeSummary:
+					count += metric.Summary().DataPoints().Len()
+				case pmetric.MetricTypeExponentialHistogram:
+					count += metric.ExponentialHistogram().DataPoints().Len()
+				}
+			}
+		}
+	}
+	return count
+}

--- a/internal/metricutil/metricutil_test.go
+++ b/internal/metricutil/metricutil_test.go
@@ -1,0 +1,53 @@
+package metricutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+func TestGetNumericValue(t *testing.T) {
+	dps := pmetric.NewNumberDataPointSlice()
+	intDP := dps.AppendEmpty()
+	intDP.SetIntValue(10)
+	assert.Equal(t, 10.0, GetNumericValue(intDP))
+
+	doubleDP := dps.AppendEmpty()
+	doubleDP.SetDoubleValue(1.5)
+	assert.Equal(t, 1.5, GetNumericValue(doubleDP))
+}
+
+func TestMetricPointCount(t *testing.T) {
+	md := pmetric.NewMetrics()
+	rm := md.ResourceMetrics().AppendEmpty()
+	sm := rm.ScopeMetrics().AppendEmpty()
+
+	// Gauge with two points
+	g := sm.Metrics().AppendEmpty()
+	g.SetName("gauge")
+	g.SetEmptyGauge().DataPoints().AppendEmpty()
+	g.Gauge().DataPoints().AppendEmpty()
+
+	// Sum with one point
+	s := sm.Metrics().AppendEmpty()
+	s.SetName("sum")
+	s.SetEmptySum().DataPoints().AppendEmpty()
+
+	// Histogram with one point
+	h := sm.Metrics().AppendEmpty()
+	h.SetName("hist")
+	h.SetEmptyHistogram().DataPoints().AppendEmpty()
+
+	// Exponential histogram with one point
+	eh := sm.Metrics().AppendEmpty()
+	eh.SetName("exp_hist")
+	eh.SetEmptyExponentialHistogram().DataPoints().AppendEmpty()
+
+	// Summary with one point
+	sum := sm.Metrics().AppendEmpty()
+	sum.SetName("summary")
+	sum.SetEmptySummary().DataPoints().AppendEmpty()
+
+	assert.Equal(t, 6, MetricPointCount(md))
+}

--- a/processors/adaptivetopk/benchmark_test.go
+++ b/processors/adaptivetopk/benchmark_test.go
@@ -10,6 +10,8 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/processor"
+
+	"github.com/newrelic/nrdot-process-optimization/internal/metricutil"
 )
 
 // generateTestMetrics creates a metrics batch with the specified number of processes
@@ -68,13 +70,13 @@ func generateTestMetrics(numProcesses int, numMetricsPerProcess int, hasCritical
 // BenchmarkAdaptiveTopKProcessor benchmarks the full processor with different process counts
 func BenchmarkAdaptiveTopKProcessor(b *testing.B) {
 	tests := []struct {
-		name             string
-		numProcesses     int
-		metricsPerProc   int
-		kValue           int
-		isDynamicK       bool
-		hasHysteresis    bool
-		hasCritical      bool
+		name           string
+		numProcesses   int
+		metricsPerProc int
+		kValue         int
+		isDynamicK     bool
+		hasHysteresis  bool
+		hasCritical    bool
 	}{
 		{
 			name:           "Small-Static-NoCritical",
@@ -218,7 +220,7 @@ func BenchmarkFindHostLoadMetric(b *testing.B) {
 	})
 }
 
-// BenchmarkMetricPointCount benchmarks the getMetricPointCount function
+// BenchmarkMetricPointCount benchmarks the MetricPointCount utility
 func BenchmarkMetricPointCount(b *testing.B) {
 	// Generate metrics with different scales
 	smallMetrics := generateTestMetrics(50, 3, false)
@@ -227,19 +229,19 @@ func BenchmarkMetricPointCount(b *testing.B) {
 
 	b.Run("SmallMetrics", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			getMetricPointCount(smallMetrics)
+			metricutil.MetricPointCount(smallMetrics)
 		}
 	})
 
 	b.Run("MediumMetrics", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			getMetricPointCount(mediumMetrics)
+			metricutil.MetricPointCount(mediumMetrics)
 		}
 	})
 
 	b.Run("LargeMetrics", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			getMetricPointCount(largeMetrics)
+			metricutil.MetricPointCount(largeMetrics)
 		}
 	})
 }

--- a/processors/adaptivetopk/processor_test.go
+++ b/processors/adaptivetopk/processor_test.go
@@ -11,6 +11,8 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/processor"
+
+	"github.com/newrelic/nrdot-process-optimization/internal/metricutil"
 )
 
 func TestAdaptiveTopK_FixedK(t *testing.T) {
@@ -60,7 +62,7 @@ func TestAdaptiveTopK_FixedK(t *testing.T) {
 	dp3 := m3.SetEmptyGauge().DataPoints().AppendEmpty()
 	dp3.SetDoubleValue(0.3)
 	dp3.Attributes().PutStr(processPIDKey, "3")
-	
+
 	// Process 4 (Low CPU)
 	m4 := sm.Metrics().AppendEmpty()
 	m4.SetName("process.cpu.utilization")
@@ -81,10 +83,10 @@ func TestAdaptiveTopK_FixedK(t *testing.T) {
 
 	processedMetrics := nextSink.AllMetrics()
 	require.Len(t, processedMetrics, 1)
-	
+
 	// Expected PIDs: "1" (critical), "2" (top CPU), "3" (second top CPU)
 	// Metric points: dp1, dp2, dp3, dp5 (belongs to critical process 1)
-	assert.Equal(t, 4, getMetricPointCount(processedMetrics[0]), "Should have 4 data points: 1 critical (cpu), 2 top K (cpu), 1 critical (mem)")
+	assert.Equal(t, 4, metricutil.MetricPointCount(processedMetrics[0]), "Should have 4 data points: 1 critical (cpu), 2 top K (cpu), 1 critical (mem)")
 
 	foundPIDs := make(map[string]int)
 	rms := processedMetrics[0].ResourceMetrics()
@@ -177,7 +179,7 @@ func TestAdaptiveTopK_DynamicK(t *testing.T) {
 	dp3 := m3.SetEmptyGauge().DataPoints().AppendEmpty()
 	dp3.SetDoubleValue(0.3)
 	dp3.Attributes().PutStr(processPIDKey, "3")
-	
+
 	// Process 4 (Low CPU)
 	m4 := sm.Metrics().AppendEmpty()
 	m4.SetName("process.cpu.utilization")
@@ -191,7 +193,7 @@ func TestAdaptiveTopK_DynamicK(t *testing.T) {
 
 	processedMetrics := nextSink.AllMetrics()
 	require.Len(t, processedMetrics, 1)
-	
+
 	// Expected PIDs: "1" (critical), "2" (highest), "3" (second highest)
 	foundPIDs := make(map[string]bool)
 	rms := processedMetrics[0].ResourceMetrics()
@@ -257,7 +259,7 @@ func TestAdaptiveTopK_DynamicK(t *testing.T) {
 	dp3 = m3.SetEmptyGauge().DataPoints().AppendEmpty()
 	dp3.SetDoubleValue(0.3)
 	dp3.Attributes().PutStr(processPIDKey, "3")
-	
+
 	m4 = sm.Metrics().AppendEmpty()
 	m4.SetName("process.cpu.utilization")
 	dp4 = m4.SetEmptyGauge().DataPoints().AppendEmpty()
@@ -375,11 +377,11 @@ func TestProcessHysteresis(t *testing.T) {
 
 	processedMetrics := nextSink.AllMetrics()
 	require.Len(t, processedMetrics, 1)
-	
+
 	// First batch - check what we actually got
 	foundPIDs := extractPIDs(processedMetrics[0])
 	t.Logf("First batch PIDs: %v", foundPIDs)
-	
+
 	// The test expected 2 and 3, but it appears we're only getting 3
 	// This is likely due to the K value of 1 in the test configuration
 	assert.Contains(t, foundPIDs, "3", "Process 3 should be present (highest CPU)")
@@ -425,11 +427,11 @@ func TestProcessHysteresis(t *testing.T) {
 
 	processedMetrics = nextSink.AllMetrics()
 	require.Len(t, processedMetrics, 1)
-	
+
 	// Second batch - check what we actually got
 	foundPIDs = extractPIDs(processedMetrics[0])
 	t.Logf("Second batch PIDs: %v", foundPIDs)
-	
+
 	// With K=1, we should get the highest CPU process (1) plus 3 due to hysteresis
 	assert.Contains(t, foundPIDs, "1", "Process 1 should be present (now in top K)")
 	assert.Contains(t, foundPIDs, "3", "Process 3 should still be present due to hysteresis")
@@ -477,11 +479,11 @@ func TestProcessHysteresis(t *testing.T) {
 
 	processedMetrics = nextSink.AllMetrics()
 	require.Len(t, processedMetrics, 1)
-	
+
 	// Third batch - check what we actually got
 	foundPIDs = extractPIDs(processedMetrics[0])
 	t.Logf("Third batch PIDs: %v", foundPIDs)
-	
+
 	// With K=1, we should only get process 1 (highest CPU), and process 3's hysteresis has expired
 	assert.Contains(t, foundPIDs, "1", "Process 1 should be present (in top K)")
 	assert.NotContains(t, foundPIDs, "3", "Process 3 should be filtered out as hysteresis expired")

--- a/processors/reservoirsampler/processor.go
+++ b/processors/reservoirsampler/processor.go
@@ -17,6 +17,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/processor"
 	"go.uber.org/zap"
+
+	"github.com/newrelic/nrdot-process-optimization/internal/metricutil"
 )
 
 type reservoirSamplerProcessor struct {
@@ -26,10 +28,10 @@ type reservoirSamplerProcessor struct {
 	obsrep       *reservoirSamplerObsreport
 
 	// Reservoir state
-	mu              sync.Mutex
-	reservoir       map[string]bool // Stores unique process identities that are sampled
-	streamCount     int64           // Count of eligible items seen so far in the stream
-	randSource      *rand.Rand      // For sampling algorithm
+	mu          sync.Mutex
+	reservoir   map[string]bool // Stores unique process identities that are sampled
+	streamCount int64           // Count of eligible items seen so far in the stream
+	randSource  *rand.Rand      // For sampling algorithm
 }
 
 func newReservoirSamplerProcessor(settings processor.CreateSettings, next consumer.Metrics, cfg *Config) (*reservoirSamplerProcessor, error) {
@@ -37,7 +39,7 @@ func newReservoirSamplerProcessor(settings processor.CreateSettings, next consum
 	if err != nil {
 		return nil, fmt.Errorf("failed to create obsreport for reservoirsampler: %w", err)
 	}
-	
+
 	// Seed random source with current time for proper randomness in production
 	rs := rand.NewSource(time.Now().UnixNano())
 
@@ -53,8 +55,10 @@ func newReservoirSamplerProcessor(settings processor.CreateSettings, next consum
 }
 
 func (p *reservoirSamplerProcessor) Start(_ context.Context, _ component.Host) error { return nil }
-func (p *reservoirSamplerProcessor) Shutdown(_ context.Context) error               { return nil }
-func (p *reservoirSamplerProcessor) Capabilities() consumer.Capabilities            { return consumer.Capabilities{MutatesData: true} }
+func (p *reservoirSamplerProcessor) Shutdown(_ context.Context) error                { return nil }
+func (p *reservoirSamplerProcessor) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: true}
+}
 
 // generateIdentity creates a unique string for a process based on configured attributes.
 func (p *reservoirSamplerProcessor) generateIdentity(attrs pcommon.Map) (string, bool) {
@@ -67,7 +71,7 @@ func (p *reservoirSamplerProcessor) generateIdentity(attrs pcommon.Map) (string,
 		identityParts = append(identityParts, key+"="+val.AsString())
 	}
 	sort.Strings(identityParts) // Ensure consistent order for the hash
-	
+
 	// Hash the identity parts for consistency and to handle arbitrary attribute values
 	h := sha256.New()
 	h.Write([]byte(strings.Join(identityParts, ";")))
@@ -79,7 +83,7 @@ func (p *reservoirSamplerProcessor) ConsumeMetrics(ctx context.Context, md pmetr
 	defer p.mu.Unlock()
 
 	ctx = p.obsrep.StartMetricsOp(ctx)
-	numOriginalMetricPoints := getMetricPointCount(md)
+	numOriginalMetricPoints := metricutil.MetricPointCount(md)
 
 	// First pass: identify eligible DPs and perform sampling logic for their identities
 	// We need to collect all unique eligible identities before modification
@@ -113,7 +117,7 @@ func (p *reservoirSamplerProcessor) ConsumeMetrics(ctx context.Context, md pmetr
 					// if topKVal, topKExists := attrs.Get(p.config.TopKAttributeName); topKExists {
 					//     continue // Skip TopK
 					// }
-					
+
 					identity, canIdentify := p.generateIdentity(attrs)
 					if !canIdentify {
 						continue // Cannot sample if identity cannot be formed
@@ -130,7 +134,7 @@ func (p *reservoirSamplerProcessor) ConsumeMetrics(ctx context.Context, md pmetr
 	for identity := range eligibleIdentities {
 		// Is this identity new? (not yet seen in stream)
 		if _, exists := p.reservoir[identity]; !exists {
-			p.streamCount++ // This is a new eligible identity in the logical stream
+			p.streamCount++                            // This is a new eligible identity in the logical stream
 			p.obsrep.recordEligibleIdentitiesSeen(ctx) // Count unique eligible identities
 
 			// Algorithm R variant for reservoir sampling
@@ -142,7 +146,7 @@ func (p *reservoirSamplerProcessor) ConsumeMetrics(ctx context.Context, md pmetr
 				// Reservoir is full, use random replacement
 				// Choose a random number j from 0 to streamCount-1
 				j := p.randSource.Int63n(p.streamCount)
-				
+
 				// If j < reservoirSize, replace an item at random
 				if j < int64(p.config.ReservoirSize) {
 					// Select a random item to replace
@@ -152,7 +156,7 @@ func (p *reservoirSamplerProcessor) ConsumeMetrics(ctx context.Context, md pmetr
 					}
 					idxToReplace := p.randSource.Intn(len(reservoirItems))
 					delete(p.reservoir, reservoirItems[idxToReplace])
-					
+
 					// Add the new identity
 					p.reservoir[identity] = true
 					p.obsrep.recordNewIdentityAdded(ctx)
@@ -164,13 +168,13 @@ func (p *reservoirSamplerProcessor) ConsumeMetrics(ctx context.Context, md pmetr
 	// Update obsreport metrics
 	currentSelectedCount := int64(len(p.reservoir))
 	p.obsrep.recordSelectedIdentitiesCount(ctx, currentSelectedCount)
-	
+
 	fillRatio := 0.0
 	if p.config.ReservoirSize > 0 {
 		fillRatio = float64(currentSelectedCount) / float64(p.config.ReservoirSize)
 	}
 	p.obsrep.recordReservoirFillRatio(ctx, fillRatio)
-	
+
 	// Calculate sample rate
 	sampleRate := 0.0
 	if p.streamCount > 0 && len(p.reservoir) > 0 {
@@ -180,7 +184,7 @@ func (p *reservoirSamplerProcessor) ConsumeMetrics(ctx context.Context, md pmetr
 	// Second pass: filter metrics (pass through critical & sampled, drop non-sampled eligible)
 	newMd := pmetric.NewMetrics()
 	md.ResourceMetrics().CopyTo(newMd.ResourceMetrics()) // Start with a copy
-	
+
 	newMd.ResourceMetrics().RemoveIf(func(rm pmetric.ResourceMetrics) bool {
 		rm.ScopeMetrics().RemoveIf(func(sm pmetric.ScopeMetrics) bool {
 			sm.Metrics().RemoveIf(func(metric pmetric.Metric) bool {
@@ -198,10 +202,10 @@ func (p *reservoirSamplerProcessor) ConsumeMetrics(ctx context.Context, md pmetr
 				if !isModifiableType {
 					return false // Pass through unhandled metric types
 				}
-				
+
 				dps.RemoveIf(func(dp pmetric.NumberDataPoint) bool {
 					attrs := dp.Attributes()
-					
+
 					// Priority pass-through (critical processes)
 					if prioVal, prioExists := attrs.Get(p.config.PriorityAttributeName); prioExists && prioVal.Str() == p.config.CriticalAttributeValue {
 						return false // Keep
@@ -231,41 +235,13 @@ func (p *reservoirSamplerProcessor) ConsumeMetrics(ctx context.Context, md pmetr
 		return rm.ScopeMetrics().Len() == 0 // Remove resource if all its scopes were removed
 	})
 
-	numProcessedMetricPoints := getMetricPointCount(newMd)
+	numProcessedMetricPoints := metricutil.MetricPointCount(newMd)
 	numDroppedMetricPoints := numOriginalMetricPoints - numProcessedMetricPoints
 	p.obsrep.EndMetricsOp(ctx, numProcessedMetricPoints, numDroppedMetricPoints, nil)
-	
+
 	if newMd.ResourceMetrics().Len() == 0 {
 		p.logger.Debug("All metrics were dropped by reservoir sampler, resulting in empty batch.")
-		return nil 
+		return nil
 	}
 	return p.nextConsumer.ConsumeMetrics(ctx, newMd)
-}
-
-// getMetricPointCount counts the total number of data points in a metrics collection
-func getMetricPointCount(md pmetric.Metrics) int {
-	count := 0
-	for i := 0; i < md.ResourceMetrics().Len(); i++ {
-		rm := md.ResourceMetrics().At(i)
-		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
-			sm := rm.ScopeMetrics().At(j)
-			for k := 0; k < sm.Metrics().Len(); k++ {
-				metric := sm.Metrics().At(k)
-				
-				switch metric.Type() {
-				case pmetric.MetricTypeGauge:
-					count += metric.Gauge().DataPoints().Len()
-				case pmetric.MetricTypeSum:
-					count += metric.Sum().DataPoints().Len()
-				case pmetric.MetricTypeHistogram:
-					count += metric.Histogram().DataPoints().Len()
-				case pmetric.MetricTypeSummary:
-					count += metric.Summary().DataPoints().Len()
-				case pmetric.MetricTypeExponentialHistogram:
-					count += metric.ExponentialHistogram().DataPoints().Len()
-				}
-			}
-		}
-	}
-	return count
 }


### PR DESCRIPTION
## Summary
- add `internal/metricutil` package for metric helper functions
- replace duplicated helper implementations in processors
- update unit tests and benchmarks
- add tests for the new package

## Testing
- `go vet ./...` *(fails: proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host)*