### PR TITLE
Add processor ordering comment

### DIFF
--- a/config/opt-plus.yaml
+++ b/config/opt-plus.yaml
@@ -157,6 +157,8 @@ service:
   pipelines:
     metrics:
       receivers: [hostmetrics]
+        # Processor order (per docs/OPTIMIZATION_PIPELINE.md):
+        # memory_limiter -> prioritytagger -> adaptivetopk -> reservoirsampler -> othersrollup -> batch
       processors: [
         memory_limiter,
         prioritytagger,     # L0: Tag critical processes


### PR DESCRIPTION
## Summary
- add comment summarizing required processor order in `opt-plus.yaml`

## Testing
- `make test` *(fails: proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host)*