### PR TITLE
Align EndMetricsOp signature

### DIFF
--- a/docs/DEVELOPING_PROCESSORS.md
+++ b/docs/DEVELOPING_PROCESSORS.md
@@ -50,10 +50,10 @@ if err != nil {
 }
 
 // Start metrics observation
-ctx, numPoints := p.obsrecv.StartMetricsOp(ctx)
+ctx = p.obsrecv.StartMetricsOp(ctx)
 
 // End metrics observation
-p.obsrecv.EndMetricsOp(ctx, p.config.ProcessorType(), metricCount, nil)
+p.obsrecv.EndMetricsOp(ctx, metricCount, 0, nil)
 ```
 
 ### Custom Processor KPIs

--- a/processors/helloworld/obsreport.go
+++ b/processors/helloworld/obsreport.go
@@ -48,12 +48,14 @@ func (orh *obsreportHelper) StartMetricsOp(ctx context.Context) context.Context 
 }
 
 // EndMetricsOp ends the metrics operation and records the number of processed metrics.
-func (orh *obsreportHelper) EndMetricsOp(ctx context.Context, processorName string, numReceivedItems int, err error) {
+func (orh *obsreportHelper) EndMetricsOp(ctx context.Context, numProcessedPoints int, numDroppedPoints int, err error) {
 	// Record the number of processed points
-	orh.processedPoints.Add(ctx, int64(numReceivedItems))
+	if orh.processedPoints != nil {
+		orh.processedPoints.Add(ctx, int64(numProcessedPoints))
+	}
 
-	// If there was an error, record dropped points
-	if err != nil {
-		orh.droppedPoints.Add(ctx, int64(numReceivedItems))
+	// Record dropped points
+	if orh.droppedPoints != nil && numDroppedPoints > 0 {
+		orh.droppedPoints.Add(ctx, int64(numDroppedPoints))
 	}
 }

--- a/processors/helloworld/processor.go
+++ b/processors/helloworld/processor.go
@@ -64,7 +64,7 @@ func (p *helloWorldProcessor) ConsumeMetrics(ctx context.Context, md pmetric.Met
 	metricCount := p.processMetrics(ctx, md)
 
 	// Record the observation and the number of processed items
-	p.obsrecv.EndMetricsOp(ctx, p.config.ProcessorType(), metricCount, nil)
+	p.obsrecv.EndMetricsOp(ctx, metricCount, 0, nil)
 
 	// Increment our custom mutation counter metric
 	p.mutationsCounter.Add(ctx, int64(metricCount))

--- a/processors/prioritytagger/obsreport.go
+++ b/processors/prioritytagger/obsreport.go
@@ -66,15 +66,15 @@ func (orh *obsreportHelper) StartMetricsOp(ctx context.Context) context.Context 
 }
 
 // EndMetricsOp ends the metrics operation and records the number of processed metrics.
-func (orh *obsreportHelper) EndMetricsOp(ctx context.Context, processorName string, numReceivedItems int, err error) {
+func (orh *obsreportHelper) EndMetricsOp(ctx context.Context, numProcessedPoints int, numDroppedPoints int, err error) {
 	// Record the number of processed points
 	if orh.processedPoints != nil {
-		orh.processedPoints.Add(ctx, int64(numReceivedItems))
+		orh.processedPoints.Add(ctx, int64(numProcessedPoints))
 	}
 
-	// If there was an error, record dropped points
-	if err != nil && orh.droppedPoints != nil {
-		orh.droppedPoints.Add(ctx, int64(numReceivedItems))
+	// Record dropped points
+	if orh.droppedPoints != nil && numDroppedPoints > 0 {
+		orh.droppedPoints.Add(ctx, int64(numDroppedPoints))
 	}
 }
 

--- a/processors/prioritytagger/processor.go
+++ b/processors/prioritytagger/processor.go
@@ -58,7 +58,7 @@ func (p *priorityTaggerProcessor) ConsumeMetrics(ctx context.Context, md pmetric
 	processedCount := p.processMetrics(ctx, md)
 
 	// Record the observation and the number of processed items
-	p.obsrecv.EndMetricsOp(ctx, p.config.ProcessorType(), processedCount, nil)
+	p.obsrecv.EndMetricsOp(ctx, processedCount, 0, nil)
 
 	// Send the modified metrics to the next consumer
 	return p.metricsConsumer.ConsumeMetrics(ctx, md)


### PR DESCRIPTION
## Summary
- standardize EndMetricsOp signature for helloworld and prioritytagger processors
- update processor calls accordingly
- refresh docs to show new signature

## Testing
- `GOTOOLCHAIN=local go test ./...` *(fails: no route to host)*