### PR TITLE
Update StartMetricsOp example

### DIFF
--- a/docs/DEVELOPING_PROCESSORS.md
+++ b/docs/DEVELOPING_PROCESSORS.md
@@ -50,7 +50,7 @@ if err != nil {
 }
 
 // Start metrics observation
-ctx, numPoints := p.obsrecv.StartMetricsOp(ctx)
+ctx = p.obsrecv.StartMetricsOp(ctx)
 
 // End metrics observation
 p.obsrecv.EndMetricsOp(ctx, p.config.ProcessorType(), metricCount, nil)


### PR DESCRIPTION
## Summary
- fix StartMetricsOp usage in Developing Processors guide

## Testing
- `go vet ./...` *(fails: proxyconnect tcp: dial tcp 172.25.0.3:8080: connect: no route to host)*
- `make lint` *(fails: proxyconnect tcp: dial tcp 172.25.0.3:8080: connect: no route to host)*
