### PR TITLE
Align HelloWorld obsreport signature

### DIFF
--- a/docs/DEVELOPING_PROCESSORS.md
+++ b/docs/DEVELOPING_PROCESSORS.md
@@ -50,10 +50,10 @@ if err != nil {
 }
 
 // Start metrics observation
-ctx, numPoints := p.obsrecv.StartMetricsOp(ctx)
+ctx = p.obsrecv.StartMetricsOp(ctx)
 
 // End metrics observation
-p.obsrecv.EndMetricsOp(ctx, p.config.ProcessorType(), metricCount, nil)
+p.obsrecv.EndMetricsOp(ctx, metricCount, 0, nil)
 ```
 
 ### Custom Processor KPIs

--- a/processors/helloworld/obsreport.go
+++ b/processors/helloworld/obsreport.go
@@ -48,12 +48,12 @@ func (orh *obsreportHelper) StartMetricsOp(ctx context.Context) context.Context 
 }
 
 // EndMetricsOp ends the metrics operation and records the number of processed metrics.
-func (orh *obsreportHelper) EndMetricsOp(ctx context.Context, processorName string, numReceivedItems int, err error) {
+func (orh *obsreportHelper) EndMetricsOp(ctx context.Context, numProcessedPoints int, numDroppedPoints int, err error) {
 	// Record the number of processed points
-	orh.processedPoints.Add(ctx, int64(numReceivedItems))
+	orh.processedPoints.Add(ctx, int64(numProcessedPoints))
 
-	// If there was an error, record dropped points
-	if err != nil {
-		orh.droppedPoints.Add(ctx, int64(numReceivedItems))
+	// Record dropped points
+	if numDroppedPoints > 0 {
+		orh.droppedPoints.Add(ctx, int64(numDroppedPoints))
 	}
 }

--- a/processors/helloworld/processor.go
+++ b/processors/helloworld/processor.go
@@ -64,7 +64,7 @@ func (p *helloWorldProcessor) ConsumeMetrics(ctx context.Context, md pmetric.Met
 	metricCount := p.processMetrics(ctx, md)
 
 	// Record the observation and the number of processed items
-	p.obsrecv.EndMetricsOp(ctx, p.config.ProcessorType(), metricCount, nil)
+	p.obsrecv.EndMetricsOp(ctx, metricCount, 0, nil)
 
 	// Increment our custom mutation counter metric
 	p.mutationsCounter.Add(ctx, int64(metricCount))


### PR DESCRIPTION
## Summary
- update `obsreport.go` in HelloWorld processor to use the common `EndMetricsOp` signature
- adjust processor implementation accordingly
- fix documentation snippet to reflect the new call pattern

## Testing
- `make lint` *(fails: proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host)*
- `GOTOOLCHAIN=local go test ./...` *(fails: proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host)*