### PR TITLE
Introduce metricsutil package and refactor point counting

### DIFF
--- a/internal/metricsutil/README.md
+++ b/internal/metricsutil/README.md
@@ -1,0 +1,11 @@
+# Metrics Util Package
+
+This package provides helper functions for working with `pmetric.Metrics`.
+
+## Available Functions
+
+| Function | Description |
+|----------|-------------|
+| `CountPoints(md pmetric.Metrics) int` | Returns the total number of data points contained in all metrics. |
+
+These helpers are intended for reuse across multiple processors.

--- a/internal/metricsutil/points.go
+++ b/internal/metricsutil/points.go
@@ -1,0 +1,30 @@
+package metricsutil
+
+import "go.opentelemetry.io/collector/pdata/pmetric"
+
+// CountPoints counts the total number of data points contained in a Metrics collection.
+func CountPoints(md pmetric.Metrics) int {
+	count := 0
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		rm := md.ResourceMetrics().At(i)
+		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+			sm := rm.ScopeMetrics().At(j)
+			for k := 0; k < sm.Metrics().Len(); k++ {
+				metric := sm.Metrics().At(k)
+				switch metric.Type() {
+				case pmetric.MetricTypeGauge:
+					count += metric.Gauge().DataPoints().Len()
+				case pmetric.MetricTypeSum:
+					count += metric.Sum().DataPoints().Len()
+				case pmetric.MetricTypeHistogram:
+					count += metric.Histogram().DataPoints().Len()
+				case pmetric.MetricTypeSummary:
+					count += metric.Summary().DataPoints().Len()
+				case pmetric.MetricTypeExponentialHistogram:
+					count += metric.ExponentialHistogram().DataPoints().Len()
+				}
+			}
+		}
+	}
+	return count
+}

--- a/internal/metricsutil/points_test.go
+++ b/internal/metricsutil/points_test.go
@@ -1,0 +1,41 @@
+package metricsutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+// TestCountPoints verifies that CountPoints correctly counts metric data points.
+func TestCountPoints(t *testing.T) {
+	md := pmetric.NewMetrics()
+
+	rm := md.ResourceMetrics().AppendEmpty()
+	sm := rm.ScopeMetrics().AppendEmpty()
+
+	// Gauge with two data points
+	m1 := sm.Metrics().AppendEmpty()
+	m1.SetEmptyGauge()
+	dp := m1.Gauge().DataPoints().AppendEmpty()
+	dp.SetIntValue(10)
+	dp = m1.Gauge().DataPoints().AppendEmpty()
+	dp.SetIntValue(20)
+
+	// Sum with one data point
+	m2 := sm.Metrics().AppendEmpty()
+	m2.SetEmptySum()
+	dp = m2.Sum().DataPoints().AppendEmpty()
+	dp.SetIntValue(5)
+
+	// Histogram with three data points
+	m3 := sm.Metrics().AppendEmpty()
+	m3.SetEmptyHistogram()
+	for i := 0; i < 3; i++ {
+		dp := m3.Histogram().DataPoints().AppendEmpty()
+		dp.SetCount(uint64(i))
+	}
+
+	// Ensure total count is 6
+	assert.Equal(t, 6, CountPoints(md))
+}

--- a/processors/adaptivetopk/benchmark_test.go
+++ b/processors/adaptivetopk/benchmark_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/newrelic/nrdot-process-optimization/internal/metricsutil"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumertest"
@@ -218,7 +219,7 @@ func BenchmarkFindHostLoadMetric(b *testing.B) {
 	})
 }
 
-// BenchmarkMetricPointCount benchmarks the getMetricPointCount function
+// BenchmarkMetricPointCount benchmarks the CountPoints helper
 func BenchmarkMetricPointCount(b *testing.B) {
 	// Generate metrics with different scales
 	smallMetrics := generateTestMetrics(50, 3, false)
@@ -227,19 +228,19 @@ func BenchmarkMetricPointCount(b *testing.B) {
 
 	b.Run("SmallMetrics", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			getMetricPointCount(smallMetrics)
+			metricsutil.CountPoints(smallMetrics)
 		}
 	})
 
 	b.Run("MediumMetrics", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			getMetricPointCount(mediumMetrics)
+			metricsutil.CountPoints(mediumMetrics)
 		}
 	})
 
 	b.Run("LargeMetrics", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			getMetricPointCount(largeMetrics)
+			metricsutil.CountPoints(largeMetrics)
 		}
 	})
 }

--- a/processors/adaptivetopk/processor.go
+++ b/processors/adaptivetopk/processor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/newrelic/nrdot-process-optimization/internal/metricsutil"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -111,7 +112,7 @@ func (p *adaptiveTopKProcessor) Capabilities() consumer.Capabilities {
 
 func (p *adaptiveTopKProcessor) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 	ctx = p.obsrep.StartMetricsOp(ctx)
-	numOriginalMetricPoints := getMetricPointCount(md)
+	numOriginalMetricPoints := metricsutil.CountPoints(md)
 
 	// Determine current K value (fixed or dynamic)
 	currentK := p.config.KValue
@@ -296,7 +297,7 @@ func (p *adaptiveTopKProcessor) ConsumeMetrics(ctx context.Context, md pmetric.M
 		return rm.ScopeMetrics().Len() == 0
 	})
 
-	numProcessedMetricPoints := getMetricPointCount(filteredMd)
+	numProcessedMetricPoints := metricsutil.CountPoints(filteredMd)
 	numDroppedMetricPoints := numOriginalMetricPoints - numProcessedMetricPoints
 	p.obsrep.EndMetricsOp(ctx, numProcessedMetricPoints, numDroppedMetricPoints, nil)
 
@@ -471,34 +472,6 @@ func (p *adaptiveTopKProcessor) applyProcessHysteresis(selectedPIDs map[string]b
 			zap.Int("hysteresisProcessCount", hysteresisCount),
 			zap.Int("totalSelectedProcesses", len(selectedPIDs)))
 	}
-}
-
-// getMetricPointCount counts the total number of data points in a metrics collection
-func getMetricPointCount(md pmetric.Metrics) int {
-	count := 0
-	for i := 0; i < md.ResourceMetrics().Len(); i++ {
-		rm := md.ResourceMetrics().At(i)
-		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
-			sm := rm.ScopeMetrics().At(j)
-			for k := 0; k < sm.Metrics().Len(); k++ {
-				metric := sm.Metrics().At(k)
-
-				switch metric.Type() {
-				case pmetric.MetricTypeGauge:
-					count += metric.Gauge().DataPoints().Len()
-				case pmetric.MetricTypeSum:
-					count += metric.Sum().DataPoints().Len()
-				case pmetric.MetricTypeHistogram:
-					count += metric.Histogram().DataPoints().Len()
-				case pmetric.MetricTypeSummary:
-					count += metric.Summary().DataPoints().Len()
-				case pmetric.MetricTypeExponentialHistogram:
-					count += metric.ExponentialHistogram().DataPoints().Len()
-				}
-			}
-		}
-	}
-	return count
 }
 
 // estimateProcessCount estimates the number of unique processes in a metrics batch

--- a/processors/adaptivetopk/processor_test.go
+++ b/processors/adaptivetopk/processor_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/newrelic/nrdot-process-optimization/internal/metricsutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
@@ -84,7 +85,7 @@ func TestAdaptiveTopK_FixedK(t *testing.T) {
 
 	// Expected PIDs: "1" (critical), "2" (top CPU), "3" (second top CPU)
 	// Metric points: dp1, dp2, dp3, dp5 (belongs to critical process 1)
-	assert.Equal(t, 4, getMetricPointCount(processedMetrics[0]), "Should have 4 data points: 1 critical (cpu), 2 top K (cpu), 1 critical (mem)")
+	assert.Equal(t, 4, metricsutil.CountPoints(processedMetrics[0]), "Should have 4 data points: 1 critical (cpu), 2 top K (cpu), 1 critical (mem)")
 
 	foundPIDs := make(map[string]int)
 	rms := processedMetrics[0].ResourceMetrics()


### PR DESCRIPTION
## Summary
- create internal/metricsutil package with CountPoints
- reuse CountPoints across processors to remove duplicate logic
- add unit test for CountPoints
- update benchmarks and tests to use new helper

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.25.0.3:8080: connect: no route to host)*