### PR TITLE
Add ProcessorType method usage for processors

### DIFF
--- a/processors/adaptivetopk/config.go
+++ b/processors/adaptivetopk/config.go
@@ -112,3 +112,8 @@ func (cfg *Config) Unmarshal(componentParser *confmap.Conf) error {
 func (cfg *Config) IsDynamicK() bool {
 	return cfg.HostLoadMetricName != ""
 }
+
+// ProcessorType returns the processor type for metrics usage
+func (cfg *Config) ProcessorType() string {
+	return typeStr
+}

--- a/processors/adaptivetopk/config_test.go
+++ b/processors/adaptivetopk/config_test.go
@@ -1,0 +1,12 @@
+package adaptivetopk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigProcessorType(t *testing.T) {
+	cfg := &Config{}
+	assert.Equal(t, "adaptivetopk", cfg.ProcessorType())
+}

--- a/processors/adaptivetopk/obsreport.go
+++ b/processors/adaptivetopk/obsreport.go
@@ -92,7 +92,7 @@ func (o *adaptiveTopKObsreport) StartMetricsOp(ctx context.Context) context.Cont
 }
 
 // EndMetricsOp ends the metrics operation and records the number of processed metrics
-func (o *adaptiveTopKObsreport) EndMetricsOp(ctx context.Context, numProcessedPoints int, numDroppedPoints int, err error) {
+func (o *adaptiveTopKObsreport) EndMetricsOp(ctx context.Context, processorName string, numProcessedPoints int, numDroppedPoints int, err error) {
 	// Record the number of processed points
 	if o.processedPoints != nil {
 		o.processedPoints.Add(ctx, int64(numProcessedPoints))

--- a/processors/adaptivetopk/processor.go
+++ b/processors/adaptivetopk/processor.go
@@ -298,7 +298,7 @@ func (p *adaptiveTopKProcessor) ConsumeMetrics(ctx context.Context, md pmetric.M
 
 	numProcessedMetricPoints := getMetricPointCount(filteredMd)
 	numDroppedMetricPoints := numOriginalMetricPoints - numProcessedMetricPoints
-	p.obsrep.EndMetricsOp(ctx, numProcessedMetricPoints, numDroppedMetricPoints, nil)
+	p.obsrep.EndMetricsOp(ctx, p.config.ProcessorType(), numProcessedMetricPoints, numDroppedMetricPoints, nil)
 
 	return p.nextConsumer.ConsumeMetrics(ctx, filteredMd)
 }

--- a/processors/othersrollup/config.go
+++ b/processors/othersrollup/config.go
@@ -79,3 +79,8 @@ func (cfg *Config) Unmarshal(componentParser *confmap.Conf) error {
 
 	return componentParser.Unmarshal(cfg)
 }
+
+// ProcessorType returns the processor type for metrics usage
+func (cfg *Config) ProcessorType() string {
+	return typeStr
+}

--- a/processors/othersrollup/config_test.go
+++ b/processors/othersrollup/config_test.go
@@ -1,0 +1,12 @@
+package othersrollup
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigProcessorType(t *testing.T) {
+	cfg := &Config{}
+	assert.Equal(t, "othersrollup", cfg.ProcessorType())
+}

--- a/processors/othersrollup/obsreport.go
+++ b/processors/othersrollup/obsreport.go
@@ -77,7 +77,7 @@ func (o *othersRollupObsreport) StartMetricsOp(ctx context.Context) context.Cont
 }
 
 // EndMetricsOp ends the metrics operation and records the number of processed metrics
-func (o *othersRollupObsreport) EndMetricsOp(ctx context.Context, numProcessedPoints int, numDroppedPoints int, err error) {
+func (o *othersRollupObsreport) EndMetricsOp(ctx context.Context, processorName string, numProcessedPoints int, numDroppedPoints int, err error) {
 	// Record the number of processed points
 	if o.processedPoints != nil {
 		o.processedPoints.Add(ctx, int64(numProcessedPoints))

--- a/processors/othersrollup/processor.go
+++ b/processors/othersrollup/processor.go
@@ -253,7 +253,7 @@ func (p *othersRollupProcessor) ConsumeMetrics(ctx context.Context, md pmetric.M
 
 	finalMetricPointCount := getMetricPointCount(newMetrics)
 	droppedCount := originalMetricPointCount - finalMetricPointCount
-	p.obsrep.EndMetricsOp(ctx, finalMetricPointCount, droppedCount, nil)
+	p.obsrep.EndMetricsOp(ctx, p.config.ProcessorType(), finalMetricPointCount, droppedCount, nil)
 
 	if newMetrics.ResourceMetrics().Len() == 0 {
 		p.logger.Debug("All metrics were rolled up or dropped, resulting in empty batch.")

--- a/processors/reservoirsampler/config.go
+++ b/processors/reservoirsampler/config.go
@@ -66,3 +66,8 @@ func (cfg *Config) Unmarshal(componentParser *confmap.Conf) error {
 
 	return componentParser.Unmarshal(cfg)
 }
+
+// ProcessorType returns the processor type for metrics usage
+func (cfg *Config) ProcessorType() string {
+	return typeStr
+}

--- a/processors/reservoirsampler/config_test.go
+++ b/processors/reservoirsampler/config_test.go
@@ -1,0 +1,12 @@
+package reservoirsampler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigProcessorType(t *testing.T) {
+	cfg := &Config{}
+	assert.Equal(t, "reservoirsampler", cfg.ProcessorType())
+}

--- a/processors/reservoirsampler/obsreport.go
+++ b/processors/reservoirsampler/obsreport.go
@@ -99,7 +99,7 @@ func (o *reservoirSamplerObsreport) StartMetricsOp(ctx context.Context) context.
 }
 
 // EndMetricsOp ends the metrics operation and records the number of processed metrics
-func (o *reservoirSamplerObsreport) EndMetricsOp(ctx context.Context, numProcessedPoints int, numDroppedPoints int, err error) {
+func (o *reservoirSamplerObsreport) EndMetricsOp(ctx context.Context, processorName string, numProcessedPoints int, numDroppedPoints int, err error) {
 	// Record the number of processed points
 	if o.processedPoints != nil {
 		o.processedPoints.Add(ctx, int64(numProcessedPoints))

--- a/processors/reservoirsampler/processor.go
+++ b/processors/reservoirsampler/processor.go
@@ -235,7 +235,7 @@ func (p *reservoirSamplerProcessor) ConsumeMetrics(ctx context.Context, md pmetr
 
 	numProcessedMetricPoints := getMetricPointCount(newMd)
 	numDroppedMetricPoints := numOriginalMetricPoints - numProcessedMetricPoints
-	p.obsrep.EndMetricsOp(ctx, numProcessedMetricPoints, numDroppedMetricPoints, nil)
+	p.obsrep.EndMetricsOp(ctx, p.config.ProcessorType(), numProcessedMetricPoints, numDroppedMetricPoints, nil)
 
 	if newMd.ResourceMetrics().Len() == 0 {
 		p.logger.Debug("All metrics were dropped by reservoir sampler, resulting in empty batch.")


### PR DESCRIPTION
## Summary
- add `ProcessorType()` to AdaptiveTopK, OthersRollup and ReservoirSampler configs
- pass the processor type when recording obsreport metrics
- unit test processor type strings

## Testing
- `GOTOOLCHAIN=local GOPROXY=off go test ./...` *(fails: module lookup disabled)*